### PR TITLE
implement 'reset' method for underlying websocket

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -47,6 +47,7 @@ var DDPClient = function(opts) {
   // internal stuff to track callbacks
   self._isConnecting = false;
   self._isReconnecting = false;
+  self._isResetting = false;
   self._nextId = 0;
   self._callbacks = {};
   self._updatedCallbacks = {};
@@ -89,7 +90,9 @@ DDPClient.prototype._prepareHandlers = function() {
 
   self.socket.on("close", function(event) {
     self.emit("socket-close", event.code, event.reason);
-    self._endPendingMethodCalls();
+    if (!self._isResetting) {
+      self._endPendingMethodCalls();
+    }
     self._recoverNetworkError();
   });
 
@@ -109,7 +112,7 @@ DDPClient.prototype._clearReconnectTimeout = function() {
 
 DDPClient.prototype._recoverNetworkError = function() {
   var self = this;
-  if (self.autoReconnect && ! self._connectionFailed && ! self._isClosing) {
+  if ((self.autoReconnect || self._isResetting) && ! self._connectionFailed && ! self._isClosing) {
     self._clearReconnectTimeout();
     self.reconnectTimeout = setTimeout(function() { self.connect(); }, self.autoReconnectTimer);
     self._isReconnecting = true;
@@ -314,6 +317,7 @@ DDPClient.prototype.connect = function(connected) {
       connected(undefined, self._isReconnecting);
       self._isConnecting = false;
       self._isReconnecting = false;
+      self._isResetting = false;
     });
     self.addListener("failed", function(error) {
       self._isConnecting = false;
@@ -328,6 +332,13 @@ DDPClient.prototype.connect = function(connected) {
     var url = self._buildWsUrl();
     self._makeWebSocketConnection(url);
   }
+};
+
+// Reset the underlying websocket connection.
+DDPClient.prototype.reset = function(connected) {
+  var self = this;
+  self._isResetting = true;
+  self.socket.close()
 };
 
 DDPClient.prototype._endPendingMethodCalls = function() {

--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -334,7 +334,9 @@ DDPClient.prototype.connect = function(connected) {
   }
 };
 
-// Reset the underlying websocket connection.
+// Reset the underlying websocket connection. This works by closing the
+// websocket, which triggers the same mechanism used by auto-reconnect (whether
+// enabled or not).
 DDPClient.prototype.reset = function(connected) {
   var self = this;
   self._isResetting = true;


### PR DESCRIPTION
The reset method implements the hack that was being accomplished by touching the lib's private members. This is tested in the context of the connector host, and recovery behavior is the same.